### PR TITLE
fix flake checks

### DIFF
--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -11,7 +11,6 @@
   ## These will be present on every NixOS machine by default.
   coreModules = [
     ../modules/core
-    ../secrets
 
     inputs.agenix.nixosModules.default
     inputs.home-manager.nixosModules.default
@@ -69,6 +68,7 @@
           }
         ]
         ++ coreModules
+        ++ (optionals (!isWSL) [../secrets])
         ++ modules
         ++ (optionals (length homeModules != 0) [(makeHome isWSL homeModules system)]);
     };
@@ -82,7 +82,6 @@ in {
       ../modules/core/docker.nix
       ../modules/core/sound.nix
 
-      ../modules/docker.nix
       ../modules/steam.nix
       ../modules/desktop/kde.nix
       ../modules/hw/nvidia.nix
@@ -97,7 +96,6 @@ in {
 
       ../home/alacritty.nix
       ../home/firefox.nix
-      ../home/gaming.nix
       ../home/git.nix
       ../home/gpg.nix
       ../home/packages
@@ -157,7 +155,7 @@ in {
     homeModules = [
       ../home/git.nix
       ../home/gpg.nix
-      ../home/programs.nix
+      ../home/packages
       ../home/xdg.nix
       ../home/zsh.nix
 

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -148,6 +148,7 @@ in {
     system = "x86_64-linux";
     modules = [
       ./spectre.nix
+      ../modules/core/docker.nix
 
       inputs.nixos-wsl.nixosModules.wsl
     ];

--- a/hosts/spectre.nix
+++ b/hosts/spectre.nix
@@ -6,7 +6,6 @@
     defaultUser = "vale";
     startMenuLaunchers = true;
 
-    docker-native.enable = true;
     docker-desktop.enable = true;
   };
 


### PR DESCRIPTION
modules/docker.nix was moved to modules/core/docker.nix and is already included
home/gaming.nix was moved to home/packages/games.nix and is already included
home/programs.nix was moved to home/packages

wsl.docker-native removed see https://github.com/nix-community/NixOS-WSL/releases/tag/23.5.5.0
we instead just enable the normal docker module

secrets module was removed from core modules as spectre cannot use it due to the lack of an ssh identity 
so it's now behind an optional that checks the host is not wsl