### PR TITLE
set system.configurationRevision

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,9 @@
     overlays = import ./overlays {inherit inputs;};
 
     # Entrypoint to all NixOS systems this config defines.
-    nixosConfigurations = import ./hosts {inherit inputs outputs;};
+    nixosConfigurations = import ./hosts {
+      inherit inputs outputs;
+      revision = self.rev or "dirty";
+    };
   };
 }

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -1,6 +1,7 @@
 {
   inputs,
   outputs,
+  revision,
   ...
 }: let
   inherit (builtins) length;
@@ -65,6 +66,8 @@
               inputs.agenix.packages.${system}.default
               outputs.packages.${system}.vix
             ];
+
+            system.configurationRevision = revision;
           }
         ]
         ++ coreModules


### PR DESCRIPTION
used for `nixos-version --configuration-revision` and `nixos-rebuild list-generations` to see which git revision the generation was built with